### PR TITLE
Bugfix: use correct user-group relation direction

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,8 +207,15 @@ If session header is missing or invalid. The header should be automatically set 
 |-------------|------------------|----------------------|----------------------------|
 | identifier  | `dct:identifier` | `xsd:string`         | Identifier of the person   |
 | name        | `foaf:name`      | `xsd:string`         | Name of the person         |
-| user-groups | `foaf:member`    | `foaf:Group`         | Groups the user belongs to |
 | account     | `foaf:account`   | `foaf:OnlineAccount` | User's account             |
+
+#### Group
+##### Class
+`foaf:Group`
+#####
+| Name        | Predicate        | Range                | Definition                 |
+|-------------|------------------|----------------------|----------------------------|
+| users       | `foaf:member`    | `foaf:Person`        | Users that belong to a group |
 
 #### Account
 ##### Class

--- a/lib/session.js
+++ b/lib/session.js
@@ -57,7 +57,7 @@ async function insertNewUser(authenticationResult) {
         ${sparqlEscapeUri(person)} a foaf:Person ;
                                  mu:uuid ${sparqlEscapeString(personUuid)} ;
                                  dct:identifier ${sparqlEscapeString(personId)} ;
-                                 foaf:member <${defaultUserGroup}> .
+         <${defaultUserGroup}> foaf:member ${sparqlEscapeUri(person)} .
     `;
 
   if (authenticationResult.account && authenticationResult.account.name)
@@ -139,7 +139,8 @@ async function getUserGroups(account) {
     SELECT ?group
     WHERE {
       GRAPH <${usersGraph}> {
-        ?person foaf:account ${sparqlEscapeUri(account)} ; foaf:member ?group .
+        ?person foaf:account ${sparqlEscapeUri(account)} .
+        ?group foaf:member ?person .
       }
     }
   `);


### PR DESCRIPTION
The relation to use for setting groups should be the other direction than what was used (a group has `foaf:member`s). This PR turns around this relationship.

this is a **BREAKING** change as apps using this service should migrate their data (and code using the groups) to turn around this relationship.
Expected version to include this PR: 3.0.0

see https://github.com/rollvolet/app-crm/pull/2 for an example migration.
